### PR TITLE
Adding CI through Code Pipeline

### DIFF
--- a/.ebextensions/README.md
+++ b/.ebextensions/README.md
@@ -1,0 +1,3 @@
+# Beanstalk Extensions
+
+These configuration files are run by each beanstalk environment. https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/ebextensions.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,13 +42,13 @@ FROM node:8.9.4-slim
 
 # Default environment variables
 ENV ROOT_URL "http://localhost"
-ENV PORT 3000
+ENV PORT 80
 
 # grab the dependencies and built app from the previous builder image
 COPY --chown=node --from=builder /opt/reaction/dist/bundle /app
 
 WORKDIR /app
 
-EXPOSE 3000
+EXPOSE 80
 
 CMD ["node", "main.js"]

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,0 +1,13 @@
+{
+  "AWSEBDockerrunVersion": 1,
+  "Image": {
+    "Name": "699870385704.dkr.ecr.us-west-2.amazonaws.com/reaction:latest",
+    "Update": "true"
+  },
+  "Ports": [
+    {
+      "ContainerPort": "80"
+    }
+  ],
+  "Volumes": []
+}

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,24 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - echo resolved source version $CODEBUILD_RESOLVED_SOURCE_VERSION
+      - echo Logging in to Amazon ECR...
+      - $(aws ecr get-login --no-include-email --region us-west-2)
+  build:
+    commands:
+      - echo Build started on `date`
+      - echo Building the Docker image...
+      - docker build -t $IMAGE_REPO:latest --build-arg TOOL_NODE_FLAGS="--max-old-space-size=4096" .
+      - docker tag $IMAGE_REPO:latest 699870385704.dkr.ecr.us-west-2.amazonaws.com/$IMAGE_REPO:latest
+      - echo Pushing the Docker image...
+      - docker push 699870385704.dkr.ecr.us-west-2.amazonaws.com/$IMAGE_REPO:latest
+  post_build:
+    commands:
+      - echo Build completed on `date`
+
+artifacts:
+  files:
+    - .ebextensions/**/*
+    - Dockerrun.aws.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,13 +41,13 @@ services:
     environment:
       METEOR_DISABLE_OPTIMISTIC_CACHING: 1
       MONGO_URL: "mongodb://mongo:27017/reaction"
-      ROOT_URL: "http://localhost:3000"
+      ROOT_URL: "http://localhost:80"
       BABEL_DISABLE_CACHE: 1 # This is needed to pick up changes to .graphql files. See https://www.npmjs.com/package/babel-plugin-inline-import#caveats
     networks:
       default:
       reaction-api:
     ports:
-      - "3000:3000"
+      - "80:80"
     volumes:
       - .:/opt/reaction/src
       - reaction_node_modules:/opt/reaction/src/node_modules # do not link node_modules in, and persist it between dc up runs

--- a/package.json
+++ b/package.json
@@ -193,11 +193,13 @@
     "devserver": "NODE_ENV=devserver nodemon .reaction/devserver/index.js",
     "lint": "eslint .",
     "test": "npm run test:unit && npm run test:integration && npm run test:app",
+    "test:ci": "npm run test:unit && npm run test:integration:ci",
     "test:app": "meteor test --once --full-app --driver-package meteortesting:mocha",
     "test:app:watch": "TEST_WATCH=1 meteor test --full-app --driver-package meteortesting:mocha",
     "test:unit": "NODE_ENV=jesttest BABEL_DISABLE_CACHE=1 jest --no-cache --testPathIgnorePatterns /tests/",
     "test:unit:watch": "NODE_ENV=jesttest BABEL_DISABLE_CACHE=1 jest --no-cache --testPathIgnorePatterns /tests/ --watch",
     "test:integration": "NODE_ENV=jesttest BABEL_DISABLE_CACHE=1 jest --no-cache /tests/",
+    "test:integration:ci": "NODE_ENV=jesttest BABEL_DISABLE_CACHE=1 jest --no-cache --forceExit /tests/",
     "test:integration:watch": "NODE_ENV=jesttest BABEL_DISABLE_CACHE=1 jest --no-cache --watch /tests/",
     "docs": "jsdoc . --configure .reaction/jsdoc/jsdoc.json --readme .reaction/jsdoc/templates/static/README.md"
   },

--- a/testspec.yml
+++ b/testspec.yml
@@ -1,0 +1,15 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - echo resolved source version $CODEBUILD_RESOLVED_SOURCE_VERSION
+  build:
+    commands:
+      - echo Build started on `date`
+      - echo Running tests
+      - npm install
+      - npm run test:ci
+  post_build:
+    commands:
+      - echo Build completed on `date`


### PR DESCRIPTION
Resolves N/A
Impact: **minor**  
Type: **deploy**

## Issue
This PR adds CI through AWS Code Pipeline.

## Solution
Whenever a change is merged to `master`, Code Pipeline will pick up the changes, test them in Code Build, build the docker image, push it to ECR, then deploy it with Beanstalk.

## Breaking changes
Changed dockerfile port from 3000 to 80. Updated port in `docker-compose.yml` to match.


## Testing
1. Push a change to master
2. Change should get propagated through https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/fakeclient-dev-reaction-deploy 
3. Change should be seen in reaction-dev.ar2jwmzisb.us-west-2.elasticbeanstalk.com